### PR TITLE
Update : Require to lowercase

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
-const Webhook = require('./classes/Webhook');
-const MessageBuilder = require('./classes/MessageBuilder');
+const Webhook = require('./classes/webhook');
+const MessageBuilder = require('./classes/messageBuilder');
 
 module.exports = {
     Webhook,


### PR DESCRIPTION
Heroku find not Webhook and MessageBuilder classes, because the require is in uppercase.
"require('./classes/Webhook')" => "require('./classes/webhook')"
Thanks