### PR TITLE
Change require to lowercase

### DIFF
--- a/src/classes/webhook.js
+++ b/src/classes/webhook.js
@@ -1,5 +1,5 @@
 const { sendWebhook, sendFile } = require('../api');
-const MessageBuilder = require('./MessageBuilder');
+const MessageBuilder = require('./messageBuilder');
 
 module.exports = class Webhook {
     constructor(options){

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
-const Webhook = require('./classes/Webhook');
-const MessageBuilder = require('./classes/MessageBuilder');
+const Webhook = require('./classes/mebhook');
+const MessageBuilder = require('./classes/messageBuilder');
 
 module.exports = {
     Webhook,


### PR DESCRIPTION
Hello ! 

I changed require to lowercase because Heroku is case-sensitive for the import.
he don't found the webhook and messageBuilder modules.

Thanks