### PR TITLE
Add support for embed author

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -84,4 +84,5 @@ export class MessageBuilder {
   setDescription(description: string): this;
   addField(fieldName: string, fieldValue: string, inline?: boolean): this;
   setFooter(footer: string, footerImage?: string): this;
+  setAuthor(name: string, iconUrl?: string, url?: string): this;
 }

--- a/src/classes/messageBuilder.js
+++ b/src/classes/messageBuilder.js
@@ -92,4 +92,13 @@ module.exports = class MessageBuilder {
 
         return this;
     };
+    
+    setAuthor(name, iconUrl, url) {
+        this.payload.embeds[0].author = {};
+        this.payload.embeds[0].author.name = name;
+        this.payload.embeds[0].author.iconURL = iconUrl;
+        this.payload.embeds[0].author.url = url;
+        
+        return this;
+    }
 };


### PR DESCRIPTION
This pull requests adds support for the "author" field in the embed's JSON - I noticed that this feature didn't exist in the current version of discord-webhook-node.