### PR TITLE
Docs: Remove 'Discord' from example

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ const { Webhook } = require('discord-webhook-node');
 const hook = new Webhook("YOUR WEBHOOK URL");
 
 const IMAGE_URL = 'https://homepages.cae.wisc.edu/~ece533/images/airplane.png';
-hook.setUsername('Discord Webhook Node Name');
+hook.setUsername('Webhook Node Name');
 hook.setAvatar(IMAGE_URL);
 
 hook.send("Hello there!");


### PR DESCRIPTION
Having the word 'discord' as in the README example raises error:

<img width="299" alt="스크린샷 2024-03-25 오후 5 33 50" src="https://github.com/matthew1232/discord-webhook-node/assets/82362278/69f30bc3-eab1-4381-a0fe-e1bdb062fe76">

.
This PR removes it from the example code snippet.